### PR TITLE
Variant support for any selected block

### DIFF
--- a/BlockPicker/BlockPickerSession.cs
+++ b/BlockPicker/BlockPickerSession.cs
@@ -60,6 +60,12 @@ namespace avaness.BlockPicker
 
         private void UpdateGizmo(MyCubeBuilderGizmo gizmo, MySlimBlock cubeBlock)
         {
+            // When the primary GUI block of the selected block's variant group
+            // is set before the selected block, the user can scroll between variants.
+            var guiVariant = cubeBlock.BlockDefinition.BlockVariantsGroup.PrimaryGUIBlock;
+            if (guiVariant != null)
+                MyCubeBuilder.Static.CubeBuilderState.UpdateCubeBlockDefinition(guiVariant.Id, gizmo.SpaceDefault.m_localMatrixAdd);
+
             MyCubeBuilder.Static.CubeBuilderState.UpdateCubeBlockDefinition(cubeBlock.BlockDefinition.Id, gizmo.SpaceDefault.m_localMatrixAdd);
 
             cubeBlock.Orientation.GetQuaternion(out Quaternion quat);


### PR DESCRIPTION
This adds variant support.

| Previously | |
| :--- | --- |
| Ctrl+G on Light Armor Block | You can scroll to any variant (slopes) |
| Ctrl+G on Light Armor Slope | You can **NOT** scroll to any variants |

*The old behavior is a bit weird but basically if you pick the first block in a variant group you can scroll to other variants*


| Now |  |
| :--- | --- |
| Ctrl+G on any block that is part of a variant group | You can scroll to variants |
| Ctrl+G on any block that is not part of a variant group (eg Ore Detector) | Picking still works 